### PR TITLE
Adding support for "Classic" Models

### DIFF
--- a/custom_components/blueair/config_flow.py
+++ b/custom_components/blueair/config_flow.py
@@ -21,12 +21,13 @@ async def validate_input(hass: core.HomeAssistant, data):
     try:
         client = await hass.async_add_executor_job(
             lambda: blueair.BlueAir(
-                username=data[CONF_USERNAME], password=data[CONF_PASSWORD]
+                username=data[CONF_USERNAME],
+                password=data[CONF_PASSWORD]
             )
         )
         LOGGER.debug(f"Connecting as {data[CONF_USERNAME]}")
     except KeyError as e:
-        raise InvalidAuth(f"BlueAir authorizarion failed")
+        raise InvalidAuth(f"BlueAir authorization failed")
     except Exception as e:
         raise CannotConnect()
 

--- a/custom_components/blueair/device.py
+++ b/custom_components/blueair/device.py
@@ -39,6 +39,8 @@ class BlueairDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=60),
         )
 
+        self._update_device()
+
     async def _async_update_data(self):
         """Update data via library."""
         try:

--- a/custom_components/blueair/fan.py
+++ b/custom_components/blueair/fan.py
@@ -27,11 +27,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     ]["devices"]
     entities = []
     for device in devices:
-        entities.extend(
-            [
-                BlueairFan(f"{device.device_name}_fan", device),
-            ]
-        )
+        if device.model != 'foobot':
+            entities.extend(
+                [
+                    BlueairFan(f"{device.device_name}_fan", device),
+                ]
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/blueair/sensor.py
+++ b/custom_components/blueair/sensor.py
@@ -27,20 +27,25 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     ]["devices"]
     entities = []
     for device in devices:
-        entities.extend(
-            [
-                BlueairTemperatureSensor(f"{device.device_name}_temperature", device),
-                BlueairHumiditySensor(f"{device.device_name}_humidity", device),
-                BlueairCO2Sensor(f"{device.device_name}_co2", device),
-                BlueairVOCSensor(f"{device.device_name}_voc", device),
-                BlueairAllPollutionSensor(
-                    f"{device.device_name}_all_pollution", device
-                ),
-                BlueairPM1Sensor(f"{device.device_name}_pm1", device),
-                BlueairPM10Sensor(f"{device.device_name}_pm10", device),
-                BlueairPM25Sensor(f"{device.device_name}_pm25", device),
-            ]
-        )
+
+
+        # Only add sensors to non-classic models
+        if not device.model.startswith('classic') and not device.model == 'foobot':
+            entities.extend(
+                [
+                    BlueairTemperatureSensor(f"{device.device_name}_temperature", device),
+                    BlueairHumiditySensor(f"{device.device_name}_humidity", device),
+                    BlueairCO2Sensor(f"{device.device_name}_co2", device),
+                    BlueairVOCSensor(f"{device.device_name}_voc", device),
+                    BlueairAllPollutionSensor(
+                        f"{device.device_name}_all_pollution", device
+                    ),
+                    BlueairPM1Sensor(f"{device.device_name}_pm1", device),
+                    BlueairPM10Sensor(f"{device.device_name}_pm10", device),
+                    BlueairPM25Sensor(f"{device.device_name}_pm25", device),
+                ]
+            )
+
     async_add_entities(entities)
 
 


### PR DESCRIPTION
Just adding this PR after I got my BlueAir Classic 605 working (fan control only).

1) Adding initial poll so attributes aren't empty
2) Disable sensors for classic models that don't contain them
3) Spelling fix in "authorization" failure

(This addresses issue #8 )